### PR TITLE
Update DevSkim workflow to use DevSkim action

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -30,9 +30,9 @@ jobs:
         uses: microsoft/DevSkim-Action@v1.0.16
         with:
           output-filename: devskim-results.sarif
-          output-directory: ${{ github.workspace }}
-
+          output-directory: .
+      
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: ${{ github.workspace }}/devskim-results.sarif
+          sarif_file: devskim-results.sarif

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -28,6 +28,9 @@ jobs:
 
       - name: DevSkim
         uses: microsoft/DevSkim-Action@v1.0.16
+        with:
+          output-filename: devskim-results.sarif
+          output-directory: ${{ github.workspace }}
 
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -26,17 +26,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "8.0.x"
+      - name: DevSkim
+        uses: microsoft/DevSkim-Action@v1.0.16
 
-      - name: Install DevSkim
-        run: dotnet tool install --global Microsoft.DevSkim.Cli
-      
-      - name: Run DevSkim
-        run: ~/.dotnet/tools/devskim analyze . --output-file devskim-results.sarif --output-format sarif
-        
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         with:

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: devskim-results.sarif
+          sarif_file: ${{ github.workspace }}/devskim-results.sarif

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -21,12 +21,21 @@ jobs:
       actions: read
       contents: read
       security-events: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Run DevSkim scanner
-        uses: microsoft/DevSkim-Action@v1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Install DevSkim
+        run: dotnet tool install --global Microsoft.DevSkim.CLI
+
+      - name: Run DevSkim
+        run: devskim analyze . --output-file devskim-results.sarif --output-format sarif
 
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -32,11 +32,11 @@ jobs:
           dotnet-version: "8.0.x"
 
       - name: Install DevSkim
-        run: dotnet tool install --global Microsoft.DevSkim.CLI
-
+        run: dotnet tool install --global Microsoft.DevSkim.Cli
+      
       - name: Run DevSkim
-        run: devskim analyze . --output-file devskim-results.sarif --output-format sarif
-
+        run: ~/.dotnet/tools/devskim analyze . --output-file devskim-results.sarif --output-format sarif
+        
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         with:


### PR DESCRIPTION
Switches the DevSkim workflow to the documented `microsoft/DevSkim-Action@v1.0.16` step and explicitly sets the SARIF output filename and path so the upload-sarif step consistently finds the results.